### PR TITLE
feat: Add ComponentScan, AutoWired, Conflict Overriding

### DIFF
--- a/src/main/java/AutoAppConfig.java
+++ b/src/main/java/AutoAppConfig.java
@@ -2,10 +2,3 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 
-@Configuration
-@ComponentScan(
-        excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION)
-)
-public class AutoAppConfig {
-
-}

--- a/src/main/java/com/example/demo/AutoAppConfig.java
+++ b/src/main/java/com/example/demo/AutoAppConfig.java
@@ -1,0 +1,21 @@
+package com.example.demo;
+
+import com.example.demo.member.MemberRepository;
+import com.example.demo.member.MemoryMemberRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+@Configuration // @Configuration : 스프링 설정 정보로 인식하고, 스프링 빈이 싱글톤을 유지하도록 추가 처리를 한다.
+@ComponentScan(
+        basePackages = "hello.core.member",  // 탐색할 패키지의 시작 위치를 지정. 이 패키지를 포함해서 하위 패키지를 모두 탐색함
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION) // 컴포넌트 스캔 대상에서 제외
+)
+public class AutoAppConfig {
+
+    @Bean(name = "memoryMemberRepository")
+    MemberRepository memberRepository(){
+        return new MemoryMemberRepository();
+    }
+}

--- a/src/main/java/com/example/demo/Order/OrderServiceImpl.java
+++ b/src/main/java/com/example/demo/Order/OrderServiceImpl.java
@@ -6,7 +6,10 @@ import com.example.demo.discount.RateDiscountPolicy;
 import com.example.demo.member.Member;
 import com.example.demo.member.MemberRepository;
 import com.example.demo.member.MemoryMemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class OrderServiceImpl implements OrderService{
 
     private final MemberRepository memberRepository; // = new MemoryMemberRepository();
@@ -18,6 +21,7 @@ public class OrderServiceImpl implements OrderService{
 
     // OrderServiceImpl 입장에서는 생성자를 통해 어떤 구현 객체가 들어올지(주입될지)는 알 수 없다.
     // 생성자를 통해서 어떤 구현 객체를 주입할지는 오직 외부(AppConfig) 에서 결정한다.
+    @Autowired
     public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy){
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;

--- a/src/main/java/com/example/demo/member/MemberServiceImpl.java
+++ b/src/main/java/com/example/demo/member/MemberServiceImpl.java
@@ -5,10 +5,20 @@ package com.example.demo.member;
 // => MemberServiceImpl 은 MemberRepository 인 추상에만 의존하면 된다. 이제 구체 클래스를 몰라도 된다.
 
 // 클라이언트인 memberServiceImpl 입장에서 보면, 의존관계를 마치 외부에서 주입해주는 것 같다고 해서 DI(Dependency Injection), 즉 의존관계 주입 또는 의존성 주입이라고 한다.
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+// 컴포넌트를 사용하면 MemberServiceImpl 을 스프링 빈으로 자동으로 들록해주고, MemberRepository 타입에 맞는 스프링 빈을 자동으로 주입해준다
+// 정리 : @Component : 스프링 빈으로 자동 등록해줌 (=> @Bean 키워드로 일일이 다 노가다로 스프링 빈으로 등록해줄 필요가 없어짐)
+// @Autowired : 생성자 쪽에 이 키워드를 붙이면, 자동으로 의존관계를 주입해줌
+@Component
 public class MemberServiceImpl implements MemberService{
     //private final MemberRepository memberRepository = new MemoryMemberRepository();
     private final MemberRepository memberRepository;
 
+    // AutoWired 기능을 생성자에 붙여주면 스프링이 MemberRepository 를 만든놈을 찾아와서 자동으로 의존관계 주입을 해준다.
+    @Autowired
     public MemberServiceImpl(MemberRepository memberRepository){
         this.memberRepository = memberRepository;
     }

--- a/src/main/java/com/example/demo/member/MemoryMemberRepository.java
+++ b/src/main/java/com/example/demo/member/MemoryMemberRepository.java
@@ -1,8 +1,11 @@
 package com.example.demo.member;
 
+import org.springframework.stereotype.Component;
+
 import java.util.HashMap;
 import java.util.Map;
 
+@Component
 public class MemoryMemberRepository implements MemberRepository {
     private static Map<Long, Member> store = new HashMap<>();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+spring.main.allow-bean-definition-overriding=true

--- a/src/test/java/com/example/demo/discount/RateDiscountPolicyTest.java
+++ b/src/test/java/com/example/demo/discount/RateDiscountPolicyTest.java
@@ -5,10 +5,12 @@ import com.example.demo.member.Member;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Component;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+@Component
 class RateDiscountPolicyTest {
     RateDiscountPolicy discountPolicy = new RateDiscountPolicy();
 

--- a/src/test/java/com/example/demo/scan/AutoAppConfigTest.java
+++ b/src/test/java/com/example/demo/scan/AutoAppConfigTest.java
@@ -1,0 +1,19 @@
+package com.example.demo.scan;
+
+import com.example.demo.AutoAppConfig;
+import com.example.demo.member.MemberService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class AutoAppConfigTest {
+
+    @Test
+    void basicScan(){
+        ApplicationContext ac = new AnnotationConfigApplicationContext(AutoAppConfig.class);
+
+        MemberService memberService = ac.getBean(MemberService.class);
+        Assertions.assertThat(memberService).isInstanceOf(MemberService.class);
+    }
+}

--- a/src/test/java/com/example/demo/scan/filter/BeanA.java
+++ b/src/test/java/com/example/demo/scan/filter/BeanA.java
@@ -1,0 +1,6 @@
+package com.example.demo.scan.filter;
+
+@MyIncludeComponent
+public class BeanA {
+
+}

--- a/src/test/java/com/example/demo/scan/filter/BeanB.java
+++ b/src/test/java/com/example/demo/scan/filter/BeanB.java
@@ -1,0 +1,6 @@
+package com.example.demo.scan.filter;
+
+@MyExcludeComponent
+public class BeanB {
+
+}

--- a/src/test/java/com/example/demo/scan/filter/ComponentFilterConfigTest.java
+++ b/src/test/java/com/example/demo/scan/filter/ComponentFilterConfigTest.java
@@ -1,0 +1,35 @@
+package com.example.demo.scan.filter;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+public class ComponentFilterConfigTest {
+
+    @Test
+    void filterScan(){
+        ApplicationContext ac = new AnnotationConfigApplicationContext(ComponentFilterAppConfig.class);
+        BeanA beanA = ac.getBean("beanA", BeanA.class);
+        Assertions.assertThat(beanA).isNotNull();
+
+        org.junit.jupiter.api.Assertions.assertThrows(
+                NoSuchBeanDefinitionException.class,
+                () -> ac.getBean("beanB", BeanB.class));
+    }
+
+    @Configuration
+    @ComponentScan(
+            // BeanA 가 스프링 빈에 등록
+            includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = MyIncludeComponent.class),
+            // BeanB 은 스프링 빈에 등록되지 않음
+            excludeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = MyExcludeComponent.class)
+    )
+    static class ComponentFilterAppConfig{
+
+    }
+}

--- a/src/test/java/com/example/demo/scan/filter/MyExcludeComponent.java
+++ b/src/test/java/com/example/demo/scan/filter/MyExcludeComponent.java
@@ -1,0 +1,9 @@
+package com.example.demo.scan.filter;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyExcludeComponent {
+}

--- a/src/test/java/com/example/demo/scan/filter/MyIncludeComponent.java
+++ b/src/test/java/com/example/demo/scan/filter/MyIncludeComponent.java
@@ -1,0 +1,9 @@
+package com.example.demo.scan.filter;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyIncludeComponent {
+}


### PR DESCRIPTION
@ Bean 을 일일히 다 주입하면서 할 부담없이, ComponentScan 을 통해 스프링 빈을 등록할 수 있게해주었다.

또한 의존관계를 자동으로 주입하기 위해 AutoWired 를 사용했다.

마지막으로 수동 의존관계 주입과 자동 의존관계 주입간에 충돌(Conflict) 가 발생하는 테스트 코드를 추가했다.
충돌을 방지하도록 application.properties 에 spring.main.allow-bean-definition-overriding=true 를 추가해서 오버라이딩 되도록 했다.
